### PR TITLE
CB-12905: (linux) Fix issue with freezing after launching the browser

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -29,7 +29,14 @@ var child_process = require('child_process'),
 module.exports = function (cmd, opt_cwd) {
     var d = Q.defer();
     try {
+        // In Linux, the callback is not called until the process terminates.
+        // If the error is not caused within 2 seconds, then the promise will be resolved.
+        var timer = process.platform === 'linux' ?
+            setTimeout(function () {
+                d.resolve('TimeOut');
+            }, 2000) : undefined;
         child_process.exec(cmd, {cwd: opt_cwd, maxBuffer: 1024000}, function (err, stdout, stderr) {
+            clearTimeout(timer);
             if (err) {
                 d.reject(new Error('Error executing "' + cmd + '": ' + stderr));
             }


### PR DESCRIPTION
In Linux, the callback is not called until the process terminates.
If the error is not caused within 2 seconds, then the promise will be resolved.

### Platforms affected
- Linux

### What does this PR do?
- If the [error after launching the browser](https://github.com/Microsoft/cordova-simulate/issues/245) is not caused within 2 seconds, then the promise will be resolved. 

### What testing has been done on this change?
- manual testing launching browsers in Linux, Windows and MacOs
