### PR TITLE
CB-13188: updated broken promise, set serve to use default browser if…

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -39,7 +39,7 @@ var NOT_SUPPORTED = 'The browser target is not supported: %target%';
 module.exports = function (opts) {
 
     opts = opts || {};
-    var target = opts.target || 'chrome';
+    var target = opts.target || 'default';
     var url = opts.url || '';
 
     target = target.toLowerCase();

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ function CordovaServe () {
     this.launchBrowser = require('./browser');
 }
 
-// module.exports.launchBrowser = require('./browser');
+module.exports.launchBrowser = require('./browser');
 
 // Expose some useful express statics
 module.exports.Router = express.Router;

--- a/src/platform.js
+++ b/src/platform.js
@@ -47,7 +47,7 @@ module.exports = function (platform, opts) {
             if (!fs.existsSync(opts.root)) {
                 reject(new Error('Error: Project does not include the specified platform: ' + platform));
             } else {
-                return that.launchServer(opts);
+                return resolve(that.launchServer(opts));
             }
         }
 


### PR DESCRIPTION
… none is provided

This PR fixes issues I found with cordova-serve as I was testing browser. I set serve to use the system default browser if none is provided. I also fixed a broken promise. 