### PR TITLE
Use `opn` module instead of deprecated `open`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^1.1.1",
     "compression": "^1.6.0",
     "express": "^4.13.3",
-    "open": "0.0.5",
+    "opn": "^5.3.0",
     "shelljs": "^0.5.3"
   },
   "devDependencies": {

--- a/src/browser.js
+++ b/src/browser.js
@@ -21,7 +21,7 @@
 
 var child_process = require('child_process');
 var fs = require('fs');
-var open = require('open');
+var open = require('opn');
 var exec = require('./exec');
 
 var NOT_INSTALLED = 'The browser target is not installed: %target%';


### PR DESCRIPTION
https://github.com/jjrdn/node-open is deprecated and recommends using [`opn`](https://github.com/sindresorhus/opn) instead