### PR TITLE
CB-14191 (android) Fix bug with module requiring

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -78,7 +78,7 @@ function getPlatformWwwRoot (cordovaProjectRoot, platformName) {
     }
 
     try {
-        var Api = require(path.join(cordovaProjectRoot, 'platforms', platformName, 'cordova/api'));
+        var Api = require(path.join(cordovaProjectRoot, 'platforms', platformName, 'cordova/Api'));
         return new Api().locations.www;
     } catch (e) {
         // Fallback on hardcoded paths if platform api not found


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:
http://cordova.apache.org/contribute/contribute_guidelines.html
Thanks!
-->

### Platforms affected

At least android.

### What does this PR do?

This PR fixes requiring `Api.js` module for case-sensitive file systems like on Linux because actual filename is upper cased. Bug leads to `Project does not include the specified platform: android error.` error when trying to start server on android platform (cordova-android@~7.0.0).

### What testing has been done on this change?

I tested it on Ubuntu 16.04 host machine with ext4 fs.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.