### PR TITLE
 CB-14198: (all) Fix bug when running simulate --target= under non-US…

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -198,7 +198,7 @@ function edgeSupported () {
     return prom;
 }
 
-var regItemPattern = /\s*\(Default\)\s+(REG_SZ)\s+([^\s].*)\s*/;
+var regItemPattern = /\s*\(.*\)\s+(REG_SZ)\s+([^\s].*)\s*/;
 function browserInstalled (browser) {
     // On Windows, the 'start' command searches the path then 'App Paths' in the registry.
     // We do the same here. Note that the start command uses the PATHEXT environment variable


### PR DESCRIPTION
… Windows 10

change regex to parse stdout from reg.exe for browser recognition to be language independent

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:
http://cordova.apache.org/contribute/contribute_guidelines.html
Thanks!
-->

### Platforms affected
all

### What does this PR do?
From https://issues.apache.org/jira/browse/CB-14198:
When running cordova simulate with a specific browser, e.g.

` simulate android --target=chrome`

the simulation does not start but instead throws an error:

```
C:\Users\pk\AppData\Roaming\npm\node_modules\cordova-simulate\node_modules\cordova-serve\src\browser.js:224
                    if (fs.existsSync(trimRegPath(result[2]))) {
                                                        ^

TypeError: Cannot read property '2' of null
    at C:\Users\pk\AppData\Roaming\npm\node_modules\cordova-simulate\node_modules\cordova-serve\src\browser.js:224:57
    at ChildProcess.exithandler (child_process.js:267:7)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Socket.stream.socket.on (internal/child_process.js:346:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:557:12)
```

Reason is a language-dependent result from reg.exe when querying the path/to/browser in the regex line 201 in browser.js.The output from reg.exe for chrome (parameter stdout) is in my configuration:

```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.EXE
    (Standard)    REG_SZ    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe

```
But the code expects (Note (Standard) vs. (Default)) :

```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.EXE
    (Default)    REG_SZ    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
```

To fix, i changed the regex in browser.js, line 201, from

`var regItemPattern = /\s*\(Default\)\s+(REG_SZ)\s+([^\s].*)\s*/;`

to

`var regItemPattern = /\s*\(.*\)\s+(REG_SZ)\s+([^\s].*)\s*/;`

to match most translations.

### What testing has been done on this change?
Only on my local machine with:
- Windows 10 German Version 1703
- cordova@8.0.0
- cordova-android@7.1.0
- cordova-simulate@0.4.0
- cordova-serve@2.0.1

It should work with english version of Windows 10 to, but i can't test.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

Please be gentle, this is my first pull request ever ...