### PR TITLE
CB-14198: (all) Fix bug when running simulate --target= under non-US Windows 10

### DIFF
--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -72,7 +72,7 @@ describe('browser', function() {
         done();
     });
 
-    it('should recognize browser from registry with key "Default" on non-English Windows 10', function(done) {
+    it('should recognize browser from registry with key "Standard" on non-English Windows 10', function(done) {
         result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -67,15 +67,13 @@ describe('browser', function() {
     });
 
     it('should recognize browser from registry with key "Default" on English Windows 10', function(done) {
-        result = browser.regItemPattern.exec(`HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE \n
-        (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`);
+        result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });
 
     it('should recognize browser from registry with key "Default" on non-English Windows 10', function(done) {
-        result = browser.regItemPattern.exec(`HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE \n
-        (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`);
+        result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -65,4 +65,19 @@ describe('browser', function() {
         browser.__set__('open', origOpen);
 
     });
+
+    it('should recognize browser from registry with key "Default" on English Windows 10', function(done) {
+        result = browser.regItemPattern.exec(`HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE \n
+        (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`);
+        expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
+        done();
+    });
+
+    it('should recognize browser from registry with key "Default" on non-English Windows 10', function(done) {
+        result = browser.regItemPattern.exec(`HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE \n
+        (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`);
+        expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
+        done();
+    });
+
 });

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -18,6 +18,7 @@ var child_process = require('child_process');
 var rewire = require('rewire');
 
 var browser = rewire("../src/browser");
+var regItemPattern = browser.__get__("regItemPattern");
 
 function expectPromise(obj){
     // 3 slightly different ways of verifying a promise
@@ -67,19 +68,19 @@ describe('browser', function() {
     });
 
     it('should recognize browser from registry with key "Default" on English Windows 10', function(done) {
-        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        var result = regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });
 
     it('should recognize browser from registry with key "Standard" on non-English Windows 10', function(done) {
-        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        var result = regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });
 
     it('should recognize browser with non-Latin registry key on Russian Windows 10', function(done) {
-        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (�� 㬮�砭��)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        var result = regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (�� 㬮�砭��)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -83,5 +83,4 @@ describe('browser', function() {
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });
-
 });

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -67,13 +67,13 @@ describe('browser', function() {
     });
 
     it('should recognize browser from registry with key "Default" on English Windows 10', function(done) {
-        result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Default)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });
 
     it('should recognize browser from registry with key "Standard" on non-English Windows 10', function(done) {
-        result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (Standard)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
         expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
         done();
     });

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -78,4 +78,10 @@ describe('browser', function() {
         done();
     });
 
+    it('should recognize browser with non-Latin registry key on Russian Windows 10', function(done) {
+        var result = browser.regItemPattern.exec("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.EXE (�� 㬮�砭��)    REG_SZ    C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe");
+        expect(result[2]).toBe("C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe")
+        done();
+    });
+
 });

--- a/src/browser.js
+++ b/src/browser.js
@@ -198,7 +198,7 @@ function edgeSupported () {
     return prom;
 }
 
-var regItemPattern = /\s*\(Default\)\s+(REG_SZ)\s+([^\s].*)\s*/;
+var regItemPattern = /\s*\(.*\)\s+(REG_SZ)\s+([^\s].*)\s*/;
 function browserInstalled (browser) {
     // On Windows, the 'start' command searches the path then 'App Paths' in the registry.
     // We do the same here. Note that the start command uses the PATHEXT environment variable

--- a/src/browser.js
+++ b/src/browser.js
@@ -236,5 +236,3 @@ function trimRegPath (path) {
     // Trim quotes and whitespace
     return path.replace(/^[\s"]+|[\s"]+$/g, '');
 }
-
-module.exports.regItemPattern = regItemPattern;

--- a/src/browser.js
+++ b/src/browser.js
@@ -198,7 +198,7 @@ function edgeSupported () {
     return prom;
 }
 
-var regItemPattern = /\s*\(.*\)\s+(REG_SZ)\s+([^\s].*)\s*/;
+var regItemPattern = /\s*\([^)]+\)\s+(REG_SZ)\s+([^\s].*)\s*/;
 function browserInstalled (browser) {
     // On Windows, the 'start' command searches the path then 'App Paths' in the registry.
     // We do the same here. Note that the start command uses the PATHEXT environment variable
@@ -236,3 +236,5 @@ function trimRegPath (path) {
     // Trim quotes and whitespace
     return path.replace(/^[\s"]+|[\s"]+$/g, '');
 }
+
+module.exports.regItemPattern = regItemPattern;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:
http://cordova.apache.org/contribute/contribute_guidelines.html
Thanks!
-->
This is an improved version of #11 PR created by @pklaes . So almost all the information was copied from there.

### Platforms affected
all

### What does this PR do?
From https://issues.apache.org/jira/browse/CB-14198:
When running cordova simulate with a specific browser, e.g.

`simulate android --target=chrome`

the simulation does not start but instead throws an error:
```
C:\Users\{username}\AppData\Roaming\npm\node_modules\cordova-simulate\node_modules\cordova-serve\src\browser.js:224
                    if (fs.existsSync(trimRegPath(result[2]))) {
                                                        ^

TypeError: Cannot read property '2' of null
    at C:\Users\{username}\AppData\Roaming\npm\node_modules\cordova-simulate\node_modules\cordova-serve\src\browser.js:224:57
    at ChildProcess.exithandler (child_process.js:267:7)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Socket.stream.socket.on (internal/child_process.js:346:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:557:12)
```
Reason is a language-dependent result from reg.exe when querying the path/to/browser in the regex line 201 in browser.js.The output from reg.exe for chrome (parameter stdout) is in my configuration:
```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.EXE
    (Standard)    REG_SZ    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
```
But the code expects (Note (Standard) vs. (Default)) :
```
HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.EXE
    (Default)    REG_SZ    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
```
### What testing has been done on this change?
Only on my local machine with:

Windows 10 English Version 1803
cordova@8.1.2
cordova-android@7.1.4
cordova-simulate@0.4.0
cordova-serve@2.0.1

Also automated tests has been added for cases where registry key for browser is not equal "Default".

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.