### PR TITLE
chore: remove appveyor allow node12 failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
   - nodejs_version: 10
   - nodejs_version: 12
 
-matrix:
-  allow_failures:
-    - nodejs_version: 12
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
### Motivation, Context, and Description
* Remove the temporary allow node 12 failures flag from AppVeyor config.

### Testing
none: Will use the AppVeyor run report for validation as its config driven.