### PR TITLE
Allow the use of custom middleware as a option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ The opts object passed to `launchServer()` and `servePlatform()` supports the fo
 * **noServerInfo**: If `true`, cordova-serve won't output `Static file server running on...` message.
 * **events**: An `EventEmitter` to use for logging. If provided, logging will be output using `events.emit('log', msg)`.
   If not provided, `console.log()` will be used. Note that nothing will be output in either case if `noLogOutput` is `true`.
+* **middleware**: Specified path for custom middleware to be used on the express server. Path is specified relative to the current working directory.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "email": "dev@cordova.apache.org"
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
     "chalk": "^2.4.1",
     "compression": "^1.6.0",
     "express": "^4.13.3",

--- a/src/platform.js
+++ b/src/platform.js
@@ -43,6 +43,7 @@ module.exports = function (platform, opts) {
             if (opts.middleware) {
                 const middlewarePath = path.join(process.cwd(), opts.middleware);
                 if (fs.existsSync(middlewarePath)) {
+                    that.app.use(require('body-parser').json());
                     that.app.use(require(middlewarePath));
                 } else {
                     throw new Error('Error: middleware can not be found');

--- a/src/platform.js
+++ b/src/platform.js
@@ -21,6 +21,7 @@
 
 var fs = require('fs');
 var util = require('./util');
+var path = require('path');
 
 /**
  * Launches a server where the root points to the specified platform in a Cordova project.
@@ -39,6 +40,14 @@ module.exports = function (platform, opts) {
             reject(new Error('Error: A platform must be specified'));
         } else {
             opts = opts || {};
+            if (opts.middleware) {
+                const middlewarePath = path.join(process.cwd(), opts.middleware);
+                if (fs.existsSync(middlewarePath)) {
+                    that.app.use(require(middlewarePath));
+                } else {
+                    throw new Error('Error: middleware can not be found');
+                }
+            }
             var projectRoot = findProjectRoot(opts.root);
             that.projectRoot = projectRoot;
             opts.root = util.getPlatformWwwRoot(projectRoot, platform);


### PR DESCRIPTION
### Platforms affected: all

### Motivation and Context
This change is intended to allow the use of custom middleware with the express server that is spun up. This change is really intended as a feature to be used with cordova-simulate: https://github.com/microsoft/cordova-simulate.

### Description
I added a middleware key to the opts object. This allows you to enter a path for your desired middleware. The middleware is verified and then added but only if you pass it the middleware key. In addition, this change does not affect any other ways to run Cordova serve. I have also added body-parser as a dependency to allow post requests to be read by the middleware.

### Testing
I tested my changes in a Cordova test app with and without my new option. Both instances ran and delivered the desired results. Further, all current unit tests ran successfully.

This PR is linked to: https://github.com/microsoft/cordova-simulate/pull/308