### PR TITLE
breaking(npm): bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "email": "dev@cordova.apache.org"
   },
   "dependencies": {
-    "chalk": "^2.4.1",
-    "compression": "^1.6.0",
-    "express": "^4.13.3",
-    "opn": "^5.3.0",
-    "which": "^1.3.0"
+    "chalk": "^3.0.0",
+    "compression": "^1.7.4",
+    "express": "^4.17.1",
+    "opn": "^6.0.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@cordova/eslint-config": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
-    "@cordova/eslint-config": "^2.0.0",
+    "@cordova/eslint-config": "^3.0.0",
     "jasmine": "^3.5.0",
-    "rewire": "^4.0.1"
+    "rewire": "^5.0.0"
   },
   "engines": {
     "node": ">= 10",


### PR DESCRIPTION
### Motivation and Context

- Keep packages up-to-date
- Support newer features/better performance/etc.
- Remove any potential npm audit warnings

**Dev Dependencies**

* `@cordova/eslint-config`@^3.0.0
* `rewire`@^5.0.0

**Dependencies**

* `chalk`@^3.0.0
* `compression`@^1.7.4
* `express`@^4.17.1
* `opn`@^6.0.0
* `which`@^2.0.2

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass