### PR TITLE
Add MS Edge Chromium support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ cordovaServe.launchBrowser(options).then(
 Options | Description
 -|-
 `url` | The URL to open in the browser.
-`target` | The browser identifier to launch. **Valid identifier**: `chrome`, `chromium`, `firefox`, `ie`, `opera`, `safari`. (**Default:** `chrome`.)
+`target` | The browser identifier to launch. **Valid identifier**: `chrome`, `chromium`, `firefox`, `ie`, `edge`, `opera`, `safari`. (**Default:** `chrome`.)
 
 **Return:**
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -68,11 +68,6 @@ module.exports = function (opts) {
                 // Furthermore, if "cmd /c" double-quoted the first parameter, then "start" will interpret it as a window title,
                 // so we need to add a dummy empty-string window title: http://stackoverflow.com/a/154090/3191
 
-                if (target === 'edge') {
-                    browser += `:${url}`;
-                    urlAdded = true;
-                }
-
                 args = ['cmd /c start ""', browser];
                 break;
             case 'linux':
@@ -112,7 +107,7 @@ function getBrowser (target, dataDir) {
             safari: 'safari',
             opera: 'opera',
             firefox: 'firefox',
-            edge: 'microsoft-edge'
+            edge: 'msedge'
         },
         darwin: {
             chrome: `"Google Chrome" --args${chromeArgs}`,
@@ -152,46 +147,19 @@ function checkBrowserExistsWindows (browser, target) {
     const promise = new Promise((resolve, reject) => {
         // Windows displays a dialog if the browser is not installed. We'd prefer to avoid that.
         if (process.platform === 'win32') {
-            if (target === 'edge') {
-                edgeSupported().then(() => {
+            browserInstalled(browser)
+                .then(() => {
                     resolve();
                 })
-                    .catch(err => {
-                        const errMessage = getErrorMessage(err, target, NOT_INSTALLED);
-                        reject(errMessage);
-                    });
-            } else {
-                browserInstalled(browser).then(() => {
-                    resolve();
-                })
-                    .catch(err => {
-                        const errMessage = getErrorMessage(err, target, NOT_INSTALLED);
-                        reject(errMessage);
-                    });
-            }
+                .catch(err => {
+                    const errMessage = getErrorMessage(err, target, NOT_INSTALLED);
+                    reject(errMessage);
+                });
         } else {
             resolve();
         }
     });
     return promise;
-}
-
-function edgeSupported () {
-    const prom = new Promise((resolve, reject) => {
-        child_process.exec('ver', (err, stdout, stderr) => {
-            if (err || stderr) {
-                reject(err || stderr);
-            } else {
-                const windowsVersion = stdout.match(/([0-9.])+/g)[0];
-                if (parseInt(windowsVersion) < 10) {
-                    reject(new Error('The browser target is not supported on this version of Windows: %target%'));
-                } else {
-                    resolve();
-                }
-            }
-        });
-    });
-    return prom;
 }
 
 const regItemPattern = /\s*\([^)]+\)\s+(REG_SZ)\s+([^\s].*)\s*/;

--- a/src/browser.js
+++ b/src/browser.js
@@ -32,7 +32,7 @@ const NOT_SUPPORTED = 'The browser target is not supported: %target%';
  * Launches the specified browser with the given URL.
  * Based on https://github.com/domenic/opener
  * @param {{target: ?string, url: ?string, dataDir: ?string}} opts - parameters:
- *   target - the target browser - ie, chrome, safari, opera, firefox or chromium
+ *   target - the target browser - ie, edge, chrome, safari, opera, firefox or chromium
  *   url - the url to open in the browser
  *   dataDir - a data dir to provide to Chrome (can be used to force it to open in a new window)
  * @return {Promise} Promise to launch the specified browser
@@ -107,13 +107,14 @@ function getBrowser (target, dataDir) {
             safari: 'safari',
             opera: 'opera',
             firefox: 'firefox',
-            edge: 'msedge'
+            edge: `msedge --user-data-dir=%TEMP%\\${dataDir}`
         },
         darwin: {
             chrome: `"Google Chrome" --args${chromeArgs}`,
             safari: 'safari',
             firefox: 'firefox',
-            opera: 'opera'
+            opera: 'opera',
+            edge: `"Microsoft Edge" --args${chromeArgs}`
         },
         linux: {
             chrome: `google-chrome${chromeArgs}`,

--- a/src/browser.js
+++ b/src/browser.js
@@ -49,7 +49,6 @@ module.exports = function (opts) {
     } else {
         return getBrowser(target, opts.dataDir).then(browser => {
             let args;
-            let urlAdded = false;
 
             switch (process.platform) {
             case 'darwin':
@@ -77,9 +76,7 @@ module.exports = function (opts) {
                 break;
             }
 
-            if (!urlAdded) {
-                args.push(url);
-            }
+            args.push(url);
             const command = args.join(' ');
             const result = exec(command);
             result.catch(() => {


### PR DESCRIPTION
Hello, 
I am a maintainer of [Cordova Tools](https://github.com/microsoft/vscode-cordova) VS Code extension and [Cordova-Simulate](https://github.com/microsoft/cordova-simulate) tool. We use the `cordova-serve` package in `Cordova-Simulate` for simulating Apache Cordova applications on different platforms (Android, iOS) in the browser.
### Platforms affected
- Microsoft Edge based on Chromium


### Motivation and Context
We have an [issue](https://github.com/microsoft/vscode-cordova/issues/588) about adding support of MS Edge Chromium. Since in `Cordova-Simulate` we use the `cordova-serve` package for launching apps in the browser, we consider that it makes sense to add a support of Edge Chromium to `cordova-serve` instead of making a local enhancement on `Cordova-Simulate` side. Also we think that it would be a useful enhancement for the `cordova-serve` package which allows to use the package for serving Cordova apps in MS Edge Chromium. 



### Description
Since the old Edge browser had become deprecated we added support of launching MS Edge Chromium on Windows and macOS.
This is a breaking change, since we removed support of non Chromium MS Edge browser. As seen Microsoft is promoting MS Edge Chromium browser and trying to replace the previous version of Edge which is not based on Chromium. We think that sooner or later the old Edge will be completely replaced on all the systems, so this PR could prepare the package to that change.

