### PR TITLE
fix(main.js): color of 404 status in console logs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,7 @@ function CordovaServe () {
     // Attach this before anything else to provide status output
     this.app.use((req, res, next) => {
         res.on('finish', function () {
-            const color = this.statusCode === '404' ? chalk.red : chalk.green;
+            const color = this.statusCode === 404 ? chalk.red : chalk.green;
             let msg = `${color(this.statusCode)} ${this.req.originalUrl}`;
             const encoding = this.getHeader('content-encoding');
             if (encoding) {


### PR DESCRIPTION
`this.statusCode` is a Number and thus the check never evaluated to true and 404 statuses were logged in green.