### PR TITLE
chore(ci): Add Node 22 to CI, drop Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:
@@ -25,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -41,10 +47,21 @@ jobs:
           node --version
           npm --version
 
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - coverage
+              - node_modules
+
       - name: npm install and test
         run: npm cit
         env:
           CI: true
+
+      - uses: github/codeql-action/analyze@v3
 
       - uses: codecov/codecov-action@v4
         if: success()


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Add current platforms, drop unsupported ones. In particular, CI was failing because `macos-latest` is arm64 now and Node 14 apparently doesn't work there.


### Description
<!-- Describe your changes in detail -->
* Add Node 22 to CI
* Remove Node 14 from CI
* Enable CodeQL scanning