### PR TITLE
chore!: drop chalk for node:util & bump node engine requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^4.1.2",
         "compression": "^1.8.1",
         "express": "^5.1.0",
         "open": "^10.2.0",
@@ -22,7 +21,7 @@
         "rewire": "^9.0.1"
       },
       "engines": {
-        "node": ">=20.9.0"
+        "node": ">=20.12.0 || >=21.7.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -503,6 +502,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -850,6 +850,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -944,6 +945,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -956,6 +958,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compressible": {
@@ -2385,6 +2388,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4426,6 +4430,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "dependencies": {
-    "chalk": "^4.1.2",
     "compression": "^1.8.1",
     "express": "^5.1.0",
     "open": "^10.2.0",
@@ -32,7 +31,7 @@
     "rewire": "^9.0.1"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=20.12.0 || >=21.7.0"
   },
   "c8": {
     "all": true,

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const chalk = require('chalk');
+const { styleText } = require('node:util');
 const compression = require('compression');
 const express = require('express');
 
@@ -28,11 +28,11 @@ class CordovaServe {
         // Attach this before anything else to provide status output
         this.app.use((req, res, next) => {
             res.on('finish', function () {
-                const color = this.statusCode === 404 ? chalk.red : chalk.green;
-                let msg = `${color(this.statusCode)} ${this.req.originalUrl}`;
+                const color = this.statusCode === 404 ? 'red' : 'green';
+                let msg = `${styleText(color, this.statusCode)} ${this.req.originalUrl}`;
                 const encoding = this.getHeader('content-encoding');
                 if (encoding) {
-                    msg += chalk.gray(` (${encoding})`);
+                    msg += styleText('gray', ` (${encoding})`);
                 }
                 require('./server').log(msg);
             });

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,7 @@
     under the License.
 */
 
-const chalk = require('chalk');
+const { styleText } = require('node:util');
 const express = require('express');
 
 /**
@@ -64,7 +64,7 @@ module.exports = function (opts) {
         const listener = server.listen(port);
         listener.on('listening', () => {
             that.port = port;
-            const message = `Static file server running on: ${chalk.green(`http://localhost:${port}`)} (CTRL + C to shut down)`;
+            const message = `Static file server running on: ${styleText('green', `http://localhost:${port}`)} (CTRL + C to shut down)`;
             if (!opts.noServerInfo) {
                 log(message);
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Drop `chalk` for `styleText` from `node:util`.

### Description
<!-- Describe your changes in detail -->

- Drop `chalk` dependency
- Replaced with `styleText` from `node:util`
- Updated node engine requirement to `>=20.12.0 || >=21.7.0` to fit `styleText` requirements.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
