### PR TITLE
fix!: update android's hard coded platform www path

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -25,7 +25,7 @@ const path = require('node:path');
 // into the actual platform.
 
 const platforms = {
-    android: { www_dir: 'assets/www' },
+    android: { www_dir: 'app/src/main/assets/www' },
     browser: { www_dir: 'www' },
     ios: { www_dir: 'www' }
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update the hard coded www directory path for Android.

### Description
<!-- Describe your changes in detail -->

Hard coded path was looking for `platforms/android/assets/www` which does not exist.
The correct location of the platform www directory was: `platforms/android/app/src/main/assets/www`

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
